### PR TITLE
Actually fix cubic chunks compatibility

### DIFF
--- a/src/main/java/xyz/vsngamer/elevator/ElevatorHandler.java
+++ b/src/main/java/xyz/vsngamer/elevator/ElevatorHandler.java
@@ -48,7 +48,7 @@ public class ElevatorHandler {
         BlockPos.MutableBlockPos toPos = new BlockPos.MutableBlockPos(fromPos);
         while (true) {
             toPos.setY(toPos.getY() + facing.getFrontOffsetY());
-            if (toPos.getY() < 8388608 || toPos.getY() >= 8388607) break;
+            if (Math.abs(toPos.getY() - fromPos.getY()) > 256) break;
             toState = world.getBlockState(toPos);
             if (toState.getBlock() == fromState.getBlock()) {
                 if (TeleportHandler.validateTarget(world, toPos)) {


### PR DESCRIPTION
The previous fix had 3 issues: 
 * missing minus sign :)
 * wrong height limits (it's actually Integer.MIN_VALUE/2 and Integeer.MAX_VALUE/2 now)
 * would freeze the client if there was no elevator block below or above

This just allows to go max 256 blcoks at once, so vanilla behavior stays the same, and works fine with cubic chunks.