### PR TITLE
Change all recipe dyes to use forge's dyes tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,14 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '1.14.4-1.5.1'
+version = '1.14.4-1.5.2'
 group = 'xyz.vsngamer.elevatorid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'elevatorid'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
 
 minecraft {
-    mappings channel: 'snapshot', version: '20190821-1.14.3'
+    mappings channel: 'snapshot', version: '20191006-1.14.3'
     runs {
         client {
             workingDirectory project.file('run')
@@ -32,7 +32,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                examplemod {
+                elevatorid {
                     source sourceSets.main
                 }
             }
@@ -48,7 +48,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                examplemod {
+                elevatorid {
                     source sourceSets.main
                 }
             }
@@ -63,10 +63,10 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
+            args '--mod', 'elevatorid', '--all', '--output', file('src/generated/resources/')
 
             mods {
-                examplemod {
+                elevatorid {
                     source sourceSets.main
                 }
             }
@@ -75,7 +75,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.14.4-28.0.55'
+    minecraft 'net.minecraftforge:forge:1.14.4-28.1.39'
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/xyz/vsngamer/elevatorid/ElevatorModTab.java
+++ b/src/main/java/xyz/vsngamer/elevatorid/ElevatorModTab.java
@@ -10,7 +10,7 @@ public class ElevatorModTab extends ItemGroup {
     public static ItemGroup TAB = new ElevatorModTab();
 
     private ElevatorModTab() {
-        super("tabElevators");
+        super("elevators_tab");
     }
 
     @Override

--- a/src/main/resources/data/elevatorid/recipes/redye_black.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_black.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:ink_sac"
+      "tag": "forge:dyes/black"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_blue.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_blue.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:blue_dye"
+      "tag": "forge:dyes/blue"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_brown.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_brown.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:brown_dye"
+      "tag": "forge:dyes/brown"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_cyan.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_cyan.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:cyan_dye"
+      "tag": "forge:dyes/cyan"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_black.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_black.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:black_dye"
+      "tag": "forge:dyes/black"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_blue.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_blue.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:blue_dye"
+      "tag": "forge:dyes/blue"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_brown.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_brown.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:brown_dye"
+      "tag": "forge:dyes/brown"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_cyan.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_cyan.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:cyan_dye"
+      "tag": "forge:dyes/cyan"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_gray.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_gray.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:gray_dye"
+      "tag": "forge:dyes/gray"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_green.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_green.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:green_dye"
+      "tag": "forge:dyes/green"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_light_blue.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_light_blue.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:light_blue_dye"
+      "tag": "forge:dyes/light_blue"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_light_gray.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_light_gray.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:light_gray_dye"
+      "tag": "forge:dyes/light_gray"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_lime.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_lime.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:lime_dye"
+      "tag": "forge:dyes/lime"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_magenta.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_magenta.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:magenta_dye"
+      "tag": "forge:dyes/magenta"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_orange.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_orange.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:orange_dye"
+      "tag": "forge:dyes/orange"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_pink.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_pink.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:pink_dye"
+      "tag": "forge:dyes/pink"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_purple.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_purple.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:purple_dye"
+      "tag": "forge:dyes/purple"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_red.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_red.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:red_dye"
+      "tag": "forge:dyes/red"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_white.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_white.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:white_dye"
+      "tag": "forge:dyes/white"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_yellow.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_dir_elevator_yellow.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:directional_elevators"
     },
     {
-      "item": "minecraft:yellow_dye"
+      "tag": "forge:dyes/yellow"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_gray.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_gray.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:gray_dye"
+      "tag": "forge:dyes/gray"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_green.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_green.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:green_dye"
+      "tag": "forge:dyes/green"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_light_blue.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_light_blue.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:light_blue_dye"
+      "tag": "forge:dyes/light_blue"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_light_gray.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_light_gray.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:light_gray_dye"
+      "tag": "forge:dyes/light_gray"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_lime.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_lime.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:lime_dye"
+      "tag": "forge:dyes/lime"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_magenta.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_magenta.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:magenta_dye"
+      "tag": "forge:dyes/magenta"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_orange.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_orange.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:orange_dye"
+      "tag": "forge:dyes/orange"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_pink.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_pink.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:pink_dye"
+      "tag": "forge:dyes/pink"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_purple.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_purple.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:purple_dye"
+      "tag": "forge:dyes/purple"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_red.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_red.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:red_dye"
+      "tag": "forge:dyes/red"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_white.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_white.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:white_dye"
+      "tag": "forge:dyes/white"
     }
   ],
   "result": {

--- a/src/main/resources/data/elevatorid/recipes/redye_yellow.json
+++ b/src/main/resources/data/elevatorid/recipes/redye_yellow.json
@@ -6,7 +6,7 @@
       "tag": "elevatorid:elevators"
     },
     {
-      "item": "minecraft:yellow_dye"
+      "tag": "forge:dyes/yellow"
     }
   ],
   "result": {


### PR DESCRIPTION
Extension to #40 
This makes all recipes compatible with other potential modded dyes by using the universal forge tags.