### PR TITLE
Fixed creative tab name(s)

### DIFF
--- a/src/main/resources/assets/elevatorid/lang/en_us.json
+++ b/src/main/resources/assets/elevatorid/lang/en_us.json
@@ -25,5 +25,5 @@
 
   "elevatorid.message.missing_xp": "You do not have enough XP to teleport",
 
-  "itemGroup.tabElevators": "Elevators"
+  "itemGroup.elevators_tab": "Elevators"
 }

--- a/src/main/resources/assets/elevatorid/lang/ko_kr.json
+++ b/src/main/resources/assets/elevatorid/lang/ko_kr.json
@@ -25,5 +25,5 @@
 
   "elevatorid.message.missing_xp": "충분한 경험치가 없어서 텔레포트를 할 수 없습니다.",
 
-  "itemGroup.tabElevators": "엘리베이터"
+  "itemGroup.elevators_tab": "엘리베이터"
 }

--- a/src/main/resources/assets/elevatorid/lang/pl_pl.json
+++ b/src/main/resources/assets/elevatorid/lang/pl_pl.json
@@ -18,5 +18,5 @@
 
   "elevatorid.subtitle.teleport": "Używana winda",
 
-  "itemGroup.tabElevators": "Elevators"
+  "itemGroup.elevators_tab": "Elevators"
 }


### PR DESCRIPTION
![2020-05-17_01 48 36](https://user-images.githubusercontent.com/5623501/82136895-b302e000-97e0-11ea-9fd9-bb0c522ea2ba.png)
See the above. I haven't tested this but I'm 100% sure it will fix it. If not you can have your money back.